### PR TITLE
Fix error handler.

### DIFF
--- a/src/api/middlewares/error-handler.js
+++ b/src/api/middlewares/error-handler.js
@@ -8,7 +8,7 @@ class ErrorHandlers {
    * @param res
    * @param next
    */
-  static apiErrorHandler(err, req, res) {
+  static apiErrorHandler(err, req, res, next) {
     if (err instanceof APIError) {
       res.status(err.code).json(err.message);
     } else {
@@ -18,6 +18,8 @@ class ErrorHandlers {
       );
       res.status(500).json("Internal Server Error");
     }
+
+    next();
   }
 
   /**


### PR DESCRIPTION
For some reason removing an unused parameter on the error handling middleware completely changed the error handling behaviour.

This PR re-adds that parameter and uses it to prevent the linter complaining. 