### PR TITLE
Component tests continued

### DIFF
--- a/src/api/controllers/VouchersController.js
+++ b/src/api/controllers/VouchersController.js
@@ -137,7 +137,9 @@ class VouchersController {
   }
 
   async validateVoucherStatus(req, res, next) {
-    const status = req.body.status;
+    const status = Array.isArray(req.body)
+      ? req.body[0].status
+      : req.body.status; // support keeper's body (array)
 
     const validVoucherStatuses = Object.values(voucherStatuses); // extract as array
 

--- a/src/api/middlewares/VoucherValidationMiddleware.js
+++ b/src/api/middlewares/VoucherValidationMiddleware.js
@@ -20,7 +20,7 @@ class VoucherValidationMiddleware {
         )
       );
     }
-
+    // console.log(voucherSupply)
     if (!voucherSupply) {
       return next(
         new ApiError(400, `Voucher with ID: ${req.params.id} does not exist!`)

--- a/src/database/Voucher/VouchersRepository.js
+++ b/src/database/Voucher/VouchersRepository.js
@@ -44,7 +44,7 @@ class VouchersRepository {
     );
   }
 
-  static async updateVoucherOnCommonEvent(voucherID, metadata) {
+  async updateVoucherOnCommonEvent(voucherID, metadata) {
     return Voucher.findByIdAndUpdate(
       voucherID,
       {
@@ -54,7 +54,7 @@ class VouchersRepository {
     );
   }
 
-  // TODO below functions actually are doind the same, we should update as per
+  // TODO below functions actually are doing the same, we should update as per
   //  collectionId, voucherId so we avoid duplication of functions
   async updateVoucherStatus(voucherId, status) {
     const voucher = await this.getVoucherById(voucherId);

--- a/src/modules/VoucherSuppliesModule.js
+++ b/src/modules/VoucherSuppliesModule.js
@@ -126,9 +126,16 @@ class VoucherSuppliesModule {
     );
 
     router.patch(
-      "/set-supply-meta",
+      "/set-supply-meta/:id",
       ErrorHandlingMiddleware.globalErrorHandler((req, res, next) =>
         this.userAuthenticationMiddleware.authenticateGCLOUDService(
+          req,
+          res,
+          next
+        )
+      ),
+      ErrorHandlingMiddleware.globalErrorHandler((req, res, next) =>
+        this.voucherValidationMiddleware.validateVoucherSupplyExists(
           req,
           res,
           next

--- a/src/modules/VouchersModule.js
+++ b/src/modules/VouchersModule.js
@@ -125,9 +125,6 @@ class VouchersModule {
         )
       ),
       ErrorHandlingMiddleware.globalErrorHandler((req, res, next) =>
-        this.vouchersController.validateVoucherStatus(req, res, next)
-      ),
-      ErrorHandlingMiddleware.globalErrorHandler((req, res, next) =>
         this.vouchersController.updateVoucherDelivered(req, res, next)
       )
     );
@@ -149,9 +146,6 @@ class VouchersModule {
         )
       ),
       ErrorHandlingMiddleware.globalErrorHandler((req, res, next) =>
-        this.vouchersController.validateVoucherStatus(req, res, next)
-      ),
-      ErrorHandlingMiddleware.globalErrorHandler((req, res, next) =>
         this.vouchersController.updateVoucherOnCommonEvent(req, res, next)
       )
     );
@@ -164,6 +158,9 @@ class VouchersModule {
           res,
           next
         )
+      ),
+      ErrorHandlingMiddleware.globalErrorHandler((req, res, next) =>
+        this.vouchersController.validateVoucherStatus(req, res, next)
       ),
       ErrorHandlingMiddleware.globalErrorHandler((req, res, next) =>
         this.vouchersController.updateStatusFromKeepers(req, res, next)

--- a/test/component/administrationResource.test.js
+++ b/test/component/administrationResource.test.js
@@ -35,7 +35,7 @@ describe("Administration Resource", () => {
     });
 
     context("on PATCH", () => {
-        // it("returns 200 and the address' admin update status", async () => {
+        // it("makeUserAdmin - returns 200 and the address' admin update status", async () => {
         //     // STEP 1 - REGISTER A USER AS ADMIN
         //     // STEP 2 - REGISTER ANOTHER USER AS NON-ADMIN
         //     // STEP 3 - USE ADMIN USER TO MAKE REQUEST TO MAKE USER 2 AN ADMIN

--- a/test/component/healthResource.test.js
+++ b/test/component/healthResource.test.js
@@ -17,7 +17,7 @@ describe("Health Resource", () => {
   });
 
   context("on GET", () => {
-    it("returns 200 and healthy body", async () => {
+    it("getHealth - returns 200 and healthy body", async () => {
       const response = await api.health().get();
 
       expect(response.statusCode).to.eql(200);

--- a/test/component/helpers/API.js
+++ b/test/component/helpers/API.js
@@ -127,6 +127,14 @@ class VoucherSuppliesResource {
         .ok(() => true);
   }
 
+  async setMetadata(voucherSupplyData, voucherSupplyId) {
+    return superagent
+        .patch(`${this.absoluteServerRoute}/set-supply-meta/${voucherSupplyId}`)
+        .authBearer(this.token)
+        .ok(() => true)
+        .send(voucherSupplyData);
+  }
+
   async delete(voucherSupplyId) {
     return superagent
         .delete(`${this.absoluteServerRoute}/${voucherSupplyId}`)
@@ -171,18 +179,61 @@ class VouchersResource {
         .ok(() => true);
   }
 
+  async getAll() {
+    return superagent
+        .get(`${this.absoluteServerRoute}/all`)
+        .authBearer(this.token)
+        .ok(() => true);
+  }
+
   async getAllPublic() {
     return superagent
         .get(`${this.absoluteServerRoute}/public`)
         .ok(() => true);
   }
 
-  async update(newStatus, voucherId) {
+  async updateStatus(voucherId, newStatus) {
     return superagent
         .patch(`${this.absoluteServerRoute}/update`)
         .authBearer(this.token)
         .ok(() => true)
         .send({ _id: voucherId, status: newStatus })
+  }
+
+  async updateDelivered(voucherTokenId, voucherIssuer, promiseId, supplyTokenId, voucherHolder, correlationId) {
+    return superagent
+        .patch(`${this.absoluteServerRoute}/update-voucher-delivered`)
+        .authBearer(this.token)
+        .ok(() => true)
+        .send({
+          _tokenIdVoucher: voucherTokenId,
+          _issuer: voucherIssuer,
+          _promiseId: promiseId,
+          _tokenIdSupply: supplyTokenId,
+          _holder: voucherHolder,
+          _correlationId: correlationId
+        });
+  }
+
+  async updateFromCommonEvent(voucherTokenId) {
+    return superagent
+        .patch(`${this.absoluteServerRoute}/update-from-common-event`)
+        .authBearer(this.token)
+        .ok(() => true)
+        .send({
+          _tokenIdVoucher: voucherTokenId
+        });
+  }
+
+  async updateStatusFromKeepers(voucherTokenId, status) {
+    return superagent
+        .patch(`${this.absoluteServerRoute}/update-status-from-keepers`)
+        .authBearer(this.token)
+        .ok(() => true)
+        .send([{
+          _tokenIdVoucher: voucherTokenId,
+          status: status
+        }]);
   }
 
   async commitToBuy(voucherSupplyId, voucherMetaData) {

--- a/test/component/helpers/Prerequisites.js
+++ b/test/component/helpers/Prerequisites.js
@@ -1,4 +1,5 @@
 const Random = require("../../shared/helpers/Random");
+const Tokens = require("../../shared/helpers/tokens");
 const { Signing } = require("../../shared/helpers/Signing");
 
 class Prerequisites {
@@ -29,6 +30,12 @@ class Prerequisites {
       .post(domain, signature);
 
     return tokenResponse.text;
+  }
+
+  getGCloudToken(gcloudSecret, tokenSecret) {
+    return Tokens.sign({
+      token: gcloudSecret,
+    }, tokenSecret);
   }
 
   /*

--- a/test/component/userResource.test.js
+++ b/test/component/userResource.test.js
@@ -34,7 +34,7 @@ describe("User Resource", () => {
   });
 
   context("on POST", () => {
-    it("returns 200 with a random nonce on success", async () => {
+    it("registerUser - returns 200 with a random nonce on success", async () => {
       const address = Random.address();
 
       const response = await (api.users().post(address));

--- a/test/component/userSignatureVerificationResource.test.js
+++ b/test/component/userSignatureVerificationResource.test.js
@@ -37,7 +37,7 @@ describe("User Signature Verification Resource", () => {
   });
 
   context("on POST", () => {
-    it("returns 200 with a JWT valid for 180 days when the signature is valid", async () => {
+    it("verifySignature - returns 200 with a JWT valid for 180 days when the signature is valid", async () => {
       const account = Random.account();
       const domain = Random.signingDomain();
       const address = account.address;
@@ -63,7 +63,7 @@ describe("User Signature Verification Resource", () => {
       expect(tokenValidityInDays).to.eql(180);
     });
 
-    it("returns 401 when the signature is incorrect", async () => {
+    it("verifySignature - returns 401 when the signature is incorrect", async () => {
       const account = Random.account();
       const domain = Random.signingDomain();
       const address = account.address;
@@ -86,7 +86,7 @@ describe("User Signature Verification Resource", () => {
       expect(response.body).to.eql("Unauthorized.");
     });
 
-    it("returns 400 when the signature is invalid", async () => {
+    it("verifySignature - returns 400 when the signature is invalid", async () => {
       const account = Random.account();
       const domain = Random.signingDomain();
       const address = account.address;

--- a/test/component/vouchersResource.test.js
+++ b/test/component/vouchersResource.test.js
@@ -16,12 +16,13 @@ describe("Vouchers Resource", () => {
     let api;
 
     const tokenSecret = Random.tokenSecret();
+    const gcloudSecret = Random.gcloudSecret();
 
     before(async () => {
         database = await Database.connect();
         server = await new TestServer()
             .onAnyPort()
-            .addConfigurationOverrides({tokenSecret})
+            .addConfigurationOverrides({tokenSecret, gcloudSecret})
             .start();
         api = new API(server.address);
         prerequisites = new Prerequisites(api);
@@ -37,7 +38,7 @@ describe("Vouchers Resource", () => {
     });
 
     context("on GET", () => {
-        it("returns 200 and all vouchers for the given address", async () => {
+        it("getAllVouchersForAddress - returns 200 and all vouchers for the given address", async () => {
             const account = Random.account();
             const token = await prerequisites.getUserToken(account);
 
@@ -56,7 +57,7 @@ describe("Vouchers Resource", () => {
             expect(Array.isArray(vouchersProperty)).to.eql(true);
         });
 
-        it("returns 200 and the requested voucher's details", async () => {
+        it("getVoucherDetails - returns 200 and the requested voucher's details", async () => {
             // CREATE VOUCHER SUPPLY
             const [token, voucherSupplyData, imageFilePath] = await prerequisites.createVoucherSupplyData();
             const [voucherSupplyId, voucherSupplyOwner] = await prerequisites.createVoucherSupply(token, voucherSupplyData, imageFilePath);
@@ -78,7 +79,7 @@ describe("Vouchers Resource", () => {
             expect(response.body.voucher._id).to.eql(voucherId); // check that IDs match
         });
 
-        it("returns 200 and all bought vouchers for the given supply ID", async () => {
+        it("getBoughtVouchers - returns 200 and all bought vouchers for the given supply ID", async () => {
             const account = Random.account();
             const token = await prerequisites.getUserToken(account);
             const supplyId = Random.voucherSupplyId();
@@ -98,7 +99,24 @@ describe("Vouchers Resource", () => {
             expect(Array.isArray(vouchersProperty)).to.eql(true);
         });
 
-        it("returns 200 and all public vouchers", async () => {
+        it("getAllVouchers - returns 200 and all vouchers", async () => {
+            const gcloudToken = await prerequisites.getGCloudToken(gcloudSecret, tokenSecret);
+
+            const response = await api
+                .withToken(gcloudToken)
+                .vouchers()
+                .getAll();
+
+            const expectedPropertyName = "vouchers";
+            const propertyNames = Object.getOwnPropertyNames(response.body);
+            const vouchersProperty = response.body[expectedPropertyName];
+
+            expect(response.status).to.eql(200);
+            expect(propertyNames).to.include(expectedPropertyName);
+            expect(Array.isArray(vouchersProperty)).to.eql(true);
+        });
+
+        it("getAllPublicVouchers - returns 200 and all public vouchers", async () => {
             const response = await api.vouchers().getAllPublic();
             const expectedPropertyName = "vouchers";
 
@@ -112,7 +130,7 @@ describe("Vouchers Resource", () => {
     });
 
     context("on PATCH", () => {
-        it("returns 200 and voucher updated success status", async () => {
+        it("updateVoucherStatus - returns 200 and voucher updated success status", async () => {
             const expectedPropertyName = "updated";
 
             // CREATE VOUCHER SUPPLY
@@ -131,7 +149,7 @@ describe("Vouchers Resource", () => {
             const response = await api
                 .withToken(token)
                 .vouchers()
-                .update(newStatus, voucherId);
+                .updateStatus(voucherId, newStatus);
 
             const propertyNames = Object.getOwnPropertyNames(response.body);
 
@@ -140,7 +158,7 @@ describe("Vouchers Resource", () => {
             expect(response.body[expectedPropertyName]).to.eql(true);
         });
 
-        it("returns 400 on voucher update to invalid status", async () => {
+        it("updateVoucherStatus - returns 400 on voucher update to invalid status", async () => {
             // CREATE VOUCHER SUPPLY
             const [token, voucherSupplyData, imageFilePath] = await prerequisites.createVoucherSupplyData();
             const [voucherSupplyId, voucherSupplyOwner] = await prerequisites.createVoucherSupply(token, voucherSupplyData, imageFilePath);
@@ -151,20 +169,184 @@ describe("Vouchers Resource", () => {
             const [createVoucherResponseCode, createVoucherResponseBody] = await prerequisites.createVoucher(token, voucherSupplyId, voucherMetadata);
             // END COMMIT TO BUY
 
-            const newStatus = "FAKE_INVALID_STATUS_TEST"; // change to invalid status
+            const newStatus = "FAKE_INVALID_STATUS_TEST"; // change to invalid status to force failure
             const voucherId = createVoucherResponseBody.voucherID;
 
             const response = await api
                 .withToken(token)
                 .vouchers()
-                .update(newStatus, voucherId);
+                .updateStatus(voucherId, newStatus);
+
+            expect(response.status).to.eql(400);
+        });
+
+        it("updateVoucherDelivered - returns 200 and updated voucher id", async () => {
+            const gcloudToken = await prerequisites.getGCloudToken(gcloudSecret, tokenSecret);
+
+            // CREATE VOUCHER SUPPLY
+            const [token, voucherSupplyData, imageFilePath] = await prerequisites.createVoucherSupplyData();
+            const [voucherSupplyId, voucherSupplyOwner] = await prerequisites.createVoucherSupply(token, voucherSupplyData, imageFilePath);
+            // END CREATE VOUCHER SUPPLY
+
+            // COMMIT TO BUY
+            const voucherMetadata = prerequisites.createVoucherMetadata(voucherSupplyOwner);
+            const [createVoucherResponseCode, createVoucherResponseBody] = await prerequisites.createVoucher(token, voucherSupplyId, voucherMetadata);
+            // END COMMIT TO BUY
+
+            const voucherTokenId = voucherMetadata._tokenIdVoucher;
+            const voucherIssuer = voucherSupplyOwner;
+            const promiseId = Random.promiseId();
+            const supplyTokenId = voucherMetadata._tokenIdSupply;
+            const voucherHolder = voucherMetadata._holder;
+            const correlationId = voucherMetadata._correlationId;
+
+            const response = await api
+                .withToken(gcloudToken)
+                .vouchers()
+                .updateDelivered(voucherTokenId, voucherIssuer, promiseId, supplyTokenId, voucherHolder, correlationId);
+
+            const expectedPropertyName = "voucher";
+            const propertyNames = Object.getOwnPropertyNames(response.body);
+
+            expect(response.status).to.eql(200);
+            expect(propertyNames).to.include(expectedPropertyName);
+        });
+
+        it("updateVoucherDelivered - returns 400 and bad request - missing voucherTokenId", async () => {
+            const gcloudToken = await prerequisites.getGCloudToken(gcloudSecret, tokenSecret);
+
+            // CREATE VOUCHER SUPPLY
+            const [token, voucherSupplyData, imageFilePath] = await prerequisites.createVoucherSupplyData();
+            const [voucherSupplyId, voucherSupplyOwner] = await prerequisites.createVoucherSupply(token, voucherSupplyData, imageFilePath);
+            // END CREATE VOUCHER SUPPLY
+
+            // COMMIT TO BUY
+            const voucherMetadata = prerequisites.createVoucherMetadata(voucherSupplyOwner);
+            const [createVoucherResponseCode, createVoucherResponseBody] = await prerequisites.createVoucher(token, voucherSupplyId, voucherMetadata);
+            // END COMMIT TO BUY
+
+            const voucherTokenId = null; // force metadata validation failure
+            const voucherIssuer = voucherSupplyOwner;
+            const promiseId = Random.promiseId();
+            const supplyTokenId = voucherMetadata._tokenIdSupply;
+            const voucherHolder = voucherMetadata._holder;
+            const correlationId = voucherMetadata._correlationId;
+
+            const response = await api
+                .withToken(gcloudToken)
+                .vouchers()
+                .updateDelivered(voucherTokenId, voucherIssuer, promiseId, supplyTokenId, voucherHolder, correlationId);
+
+            expect(response.status).to.eql(400);
+        });
+
+        it("updateVoucherFromCommonEvent - returns 200 and update success status", async () => {
+            const gcloudToken = await prerequisites.getGCloudToken(gcloudSecret, tokenSecret);
+
+            // CREATE VOUCHER SUPPLY
+            const [token, voucherSupplyData, imageFilePath] = await prerequisites.createVoucherSupplyData();
+            const [voucherSupplyId, voucherSupplyOwner] = await prerequisites.createVoucherSupply(token, voucherSupplyData, imageFilePath);
+            // END CREATE VOUCHER SUPPLY
+
+            // COMMIT TO BUY
+            const voucherMetadata = prerequisites.createVoucherMetadata(voucherSupplyOwner);
+            const [createVoucherResponseCode, createVoucherResponseBody] = await prerequisites.createVoucher(token, voucherSupplyId, voucherMetadata);
+            // END COMMIT TO BUY
+
+            const voucherTokenId = voucherMetadata._tokenIdVoucher;
+
+            const response = await api
+                .withToken(gcloudToken)
+                .vouchers()
+                .updateFromCommonEvent(voucherTokenId);
+
+            const expectedPropertyName = "updated";
+            const propertyNames = Object.getOwnPropertyNames(response.body);
+
+            expect(response.status).to.eql(200);
+            expect(propertyNames).to.include(expectedPropertyName);
+            expect(response.body[expectedPropertyName]).to.eql(true);
+        });
+
+        it("updateVoucherFromCommonEvent - returns 400 and bad request - missing voucherTokenId", async () => {
+            const gcloudToken = await prerequisites.getGCloudToken(gcloudSecret, tokenSecret);
+
+            // CREATE VOUCHER SUPPLY
+            const [token, voucherSupplyData, imageFilePath] = await prerequisites.createVoucherSupplyData();
+            const [voucherSupplyId, voucherSupplyOwner] = await prerequisites.createVoucherSupply(token, voucherSupplyData, imageFilePath);
+            // END CREATE VOUCHER SUPPLY
+
+            // COMMIT TO BUY
+            const voucherMetadata = prerequisites.createVoucherMetadata(voucherSupplyOwner);
+            const [createVoucherResponseCode, createVoucherResponseBody] = await prerequisites.createVoucher(token, voucherSupplyId, voucherMetadata);
+            // END COMMIT TO BUY
+
+            const voucherTokenId = null; // force metadata validation failure
+
+            const response = await api
+                .withToken(gcloudToken)
+                .vouchers()
+                .updateFromCommonEvent(voucherTokenId);
+
+            expect(response.status).to.eql(400);
+        });
+
+        it("updateVoucherStatusFromKeepers - returns 200 and voucher updated success status", async () => {
+            const gcloudToken = await prerequisites.getGCloudToken(gcloudSecret, tokenSecret);
+
+            // CREATE VOUCHER SUPPLY
+            const [token, voucherSupplyData, imageFilePath] = await prerequisites.createVoucherSupplyData();
+            const [voucherSupplyId, voucherSupplyOwner] = await prerequisites.createVoucherSupply(token, voucherSupplyData, imageFilePath);
+            // END CREATE VOUCHER SUPPLY
+
+            // COMMIT TO BUY
+            const voucherMetadata = prerequisites.createVoucherMetadata(voucherSupplyOwner);
+            const [createVoucherResponseCode, createVoucherResponseBody] = await prerequisites.createVoucher(token, voucherSupplyId, voucherMetadata);
+            // END COMMIT TO BUY
+
+            const newStatus = validVoucherStatuses[0]; // change to guaranteed valid status
+            const voucherTokenId = voucherMetadata._tokenIdVoucher;
+
+            const response = await api
+                .withToken(gcloudToken)
+                .vouchers()
+                .updateStatusFromKeepers(voucherTokenId, newStatus);
+
+            const expectedPropertyName = "updated";
+            const propertyNames = Object.getOwnPropertyNames(response.body);
+
+            expect(response.status).to.eql(200);
+            expect(propertyNames).to.include(expectedPropertyName);
+            expect(response.body[expectedPropertyName]).to.eql(true);
+        });
+
+        it("updateVoucherStatusFromKeepers - returns 400 on voucher update to invalid status", async () => {
+            const gcloudToken = await prerequisites.getGCloudToken(gcloudSecret, tokenSecret);
+
+            // CREATE VOUCHER SUPPLY
+            const [token, voucherSupplyData, imageFilePath] = await prerequisites.createVoucherSupplyData();
+            const [voucherSupplyId, voucherSupplyOwner] = await prerequisites.createVoucherSupply(token, voucherSupplyData, imageFilePath);
+            // END CREATE VOUCHER SUPPLY
+
+            // COMMIT TO BUY
+            const voucherMetadata = prerequisites.createVoucherMetadata(voucherSupplyOwner);
+            const [createVoucherResponseCode, createVoucherResponseBody] = await prerequisites.createVoucher(token, voucherSupplyId, voucherMetadata);
+            // END COMMIT TO BUY
+
+            const newStatus = "FAKE_INVALID_STATUS_TEST"; // change to invalid status to force failure
+            const voucherTokenId = voucherMetadata._tokenIdVoucher;
+
+            const response = await api
+                .withToken(gcloudToken)
+                .vouchers()
+                .updateStatusFromKeepers(voucherTokenId, newStatus);
 
             expect(response.status).to.eql(400);
         });
     });
 
     context("on POST", () => {
-        it("returns 200 with the voucher ID", async () => {
+        it("createVoucher - returns 200 with the voucher ID", async () => {
             // CREATE VOUCHER SUPPLY
             const [token, voucherSupplyData, imageFilePath] = await prerequisites.createVoucherSupplyData();
             const [voucherSupplyId, voucherSupplyOwner] = await prerequisites.createVoucherSupply(token, voucherSupplyData, imageFilePath);
@@ -182,7 +364,7 @@ describe("Vouchers Resource", () => {
             expect(propertyNames).to.include(expectedPropertyName);
         });
 
-        it("returns 403 with forbidden (voucher holder doesn't match requesting address)", async () => {
+        it("createVoucher - returns 403 with forbidden (voucher holder doesn't match requesting address)", async () => {
             // CREATE VOUCHER SUPPLY
             const [token, voucherSupplyData, imageFilePath] = await prerequisites.createVoucherSupplyData();
             const [voucherSupplyId, voucherSupplyOwner] = await prerequisites.createVoucherSupply(token, voucherSupplyData, imageFilePath);

--- a/test/shared/helpers/random.js
+++ b/test/shared/helpers/random.js
@@ -54,6 +54,15 @@ class Random {
     return faker.random.hexaDecimal(128).slice(2);
   }
 
+  // TODO change to match gCloudSecret format
+  static gcloudSecret() {
+    return faker.random.hexaDecimal(128).slice(2);
+  }
+
+  static promiseId() {
+    return keccak256(faker.random.alpha(64)).toString("hex");
+  }
+
   static title() {
     return faker.random.words(3);
   }
@@ -268,6 +277,7 @@ class Random {
       _tokenIdVoucher: Random.uint256(),
       _holder: Random.address(),
       _issuer: Random.address(),
+      _correlationId: Random.uint256(),
       ...overrides,
     };
   }


### PR DESCRIPTION
@HristiyanG  This includes the below change I mentioned on Slack:

Changed the VoucherSuppliesModule "/set-supply-meta" to include the supplyID as a URL param (to be consistent with other methods).
e.g. "/set-supply-meta/:id"