### PR TITLE
Sanitize PR pipeline names before pushing pipelines.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -356,7 +356,7 @@ namespace :ci do
 
         t.target = configuration.concourse_team
         t.team = configuration.concourse_team
-        t.pipeline = "reference-backend-pr-#{branch}"
+        t.pipeline = "reference-backend-pr-#{to_pipeline_name(branch)}"
 
         t.config = 'pipelines/pr/pipeline.yaml'
 
@@ -423,6 +423,10 @@ end
 
 def to_db_name(string)
   string.gsub(/[^a-zA-Z0-9_-]/, "")
+end
+
+def to_pipeline_name(string)
+  string.gsub(/[^a-zA-Z0-9_-]/, "_")
 end
 
 def database_overrides_for(configuration, args)


### PR DESCRIPTION
Currently, for branch names such as feat/xyz or release/123, the pipeline builder fails since Concourse doesn't allow characters other than a-zA-Z0-9_-.

This PR sanitizes the branch name before creating the pipeline to work around this.