### PR TITLE
Fix: CORS error caused by inclusion of indirect UUID function via test helper

### DIFF
--- a/src/api/middlewares/FileStorageMiddleware.js
+++ b/src/api/middlewares/FileStorageMiddleware.js
@@ -1,7 +1,7 @@
 const multer = require("multer");
+const { v4: uuidv4 } = require("uuid");
 
 const ApiError = require("../../api/ApiError");
-const Random = require("../../../test/shared/helpers/Random");
 
 class FileStorageMiddleware {
   constructor(fieldName, fileStore) {
@@ -53,7 +53,7 @@ class FileStorageMiddleware {
       const fileRefs = [];
 
       try {
-        const folder = Random.uuid();
+        const folder = uuidv4();
 
         for (let i = 0; i < req.files.length; i++) {
           const file = req.files[i];


### PR DESCRIPTION
Reverted to direct import of uuid() function in non-test code to avoid missing production dependency error which causes CORS error