### PR TITLE
added paymentType on voucherCreation

### DIFF
--- a/src/database/VoucherSupply/VoucherSuppliesRepository.js
+++ b/src/database/VoucherSupply/VoucherSuppliesRepository.js
@@ -39,6 +39,7 @@ class VoucherSuppliesRepository {
       _correlationId: metadata._correlationId,
       _tokenIdSupply: metadata._tokenIdSupply,
       imagefiles: fileRefs,
+      _paymentType: metadata._paymentType,
     });
 
     return voucherSupply.save();


### PR DESCRIPTION
We get the payment type coming from the FE, so we can display proper information to the user, before the EL update the actual payment Type. This is a preliminary step, just to have something more useful information to the FE 